### PR TITLE
Installs revision_plate for process heartbeat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'active_decorator'
 
 gem 'omniauth-google-oauth2'
 
+gem 'revision_plate', require: 'revision_plate/rails'
+
 gem 'puma'
 
 gem 'non-stupid-digest-assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.1.2)
+    revision_plate (0.1.2)
+      rack
     ridgepole (0.6.4)
       activerecord (~> 4.2.1)
     rinku (1.7.3)
@@ -297,6 +299,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.6)
   rails_stdout_logging
+  revision_plate
   ridgepole
   rinku
   rspec-rails


### PR DESCRIPTION
死活監視用に、デプロイリビジョンを返す /site/sha を提供したいです。 <a href="https://github.com/sorah/revision_plate">revision_plate</a> を使っています。