### PR TITLE
Do not import table schema on process start

### DIFF
--- a/app/batches/synchronize_data_sources.rb
+++ b/app/batches/synchronize_data_sources.rb
@@ -1,3 +1,7 @@
-DataSource.all.find_each do |data_source|
-  DatabaseMemo.import_data_source!(data_source.id)
+class SynchronizeDataSources
+  def self.run
+    DataSource.all.find_each do |data_source|
+      DatabaseMemo.import_data_source!(data_source.id)
+    end
+  end
 end


### PR DESCRIPTION
It takes really long and not-multiprocess-safe, we should not start synchronization on the process start.