### PR TITLE
Sorts tables in the alphabetical order

### DIFF
--- a/app/views/database_memos/show.html.haml
+++ b/app/views/database_memos/show.html.haml
@@ -46,4 +46,4 @@
         %th Name
         %th Description
         %th Columns
-      = render partial: "table_memo", collection: @database_memo.table_memos
+      = render partial: "table_memo", collection: @database_memo.table_memos.sort_by(&:name)


### PR DESCRIPTION
Currently tables are sorted in DB (random) order, it should be fixed.

parent: #22 