### PR TITLE
Should rescue all ActiveRecord::ActiveRecordError from data source

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -80,7 +80,7 @@ class DataSource < ActiveRecord::Base
       end
     end
     table_names.reject {|_, table_name| ignored_table_patterns.match(table_name) }
-  rescue ActiveRecordError, Mysql2::Error, PG::Error => e
+  rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
     raise ConnectionBad.new(e)
   end
 
@@ -106,7 +106,7 @@ class DataSource < ActiveRecord::Base
     source_table = self.class.data_source_tables_cache[id][full_table_name]
     return source_table if source_table
     self.class.data_source_tables_cache[id][full_table_name] = DataSourceTable.new(self, schema_name, table_name)
-  rescue ActiveRecordError, Mysql2::Error, PG::Error => e
+  rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
     raise ConnectionBad.new(e)
   end
 

--- a/app/models/data_source_table.rb
+++ b/app/models/data_source_table.rb
@@ -28,7 +28,7 @@ class DataSourceTable
         columns.zip(row).map {|column, value| column.type_cast_from_database(value) }
       }
     end
-  rescue Mysql2::Error, PG::Error => e
+  rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
     raise DataSource::ConnectionBad.new(e)
   end
 
@@ -38,7 +38,7 @@ class DataSourceTable
         SELECT COUNT(*) FROM #{full_table_name};
       SQL
     end
-  rescue Mysql2::Error, PG::Error => e
+  rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
     raise DataSource::ConnectionBad.new(e)
   end
 end


### PR DESCRIPTION
This pull request is supprement to #40; I'm sorry, more rescue is required to ignore permission errors from data source....