### PR TITLE
Autolink SCHEMA.TABLE to the table page.

### DIFF
--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,7 +1,9 @@
 class Keyword
   def self.links
-    @links ||= TableMemo.distinct(:name).pluck(:name).each_with_object({}) {|name, h|
-      h[name] = Rails.application.routes.url_helpers.keyword_path(name)
+    urls = Rails.application.routes.url_helpers
+    @links ||= TableMemo.joins(:schema_memo).pluck(:id, :name, 'schema_memos.name').each_with_object({}) {|(id, name, schema_name), h|
+      h[name] = urls.keyword_path(name)
+      h["#{schema_name}.#{name}"] = urls.table_memo_path(id)
     }
   end
 

--- a/spec/models/keyword_spec.rb
+++ b/spec/models/keyword_spec.rb
@@ -3,26 +3,31 @@ require "rails_helper"
 describe Keyword, type: :model do
   describe ".links" do
     before do
-      TableMemo.create!(name: "books", schema_memo_id: 0)
+      SchemaMemo.create!(id: 1, name: "myapp", database_memo_id: 0)
+      TableMemo.create!(id: 97, name: "books", schema_memo_id: 1)
     end
 
-    it { expect(Keyword.links).to eq("books" => "/keywords/books") }
+    it { expect(Keyword.links).to eq("books" => "/keywords/books", "myapp.books" => "/tables/97") }
 
     context "after table_memos created" do
       it "clears links" do
-        expect(Keyword.links).to eq("books" => "/keywords/books")
-        memo = TableMemo.create!(name: "blogs", schema_memo_id: 0)
+        expect(Keyword.links).to eq("books" => "/keywords/books", "myapp.books" => "/tables/97")
+        memo = TableMemo.create!(id: 98, name: "blogs", schema_memo_id: 1)
         expect(Keyword.links).to eq(
           "blogs" => "/keywords/blogs",
+          "myapp.blogs" => "/tables/98",
           "books" => "/keywords/books",
+          "myapp.books" => "/tables/97",
         )
         memo.update!(name: "alphabets")
         expect(Keyword.links).to eq(
           "alphabets" => "/keywords/alphabets",
+          "myapp.alphabets" => "/tables/98",
           "books" => "/keywords/books",
+          "myapp.books" => "/tables/97",
         )
         memo.destroy!
-        expect(Keyword.links).to eq("books" => "/keywords/books")
+        expect(Keyword.links).to eq("books" => "/keywords/books", "myapp.books" => "/tables/97")
       end
     end
   end


### PR DESCRIPTION
"SCHEMA_NAME.TABLE_NAME" in markdown becomes hyperlink to the table document page.