### PR TITLE
Fix full_table_name have to quote when use mysql

### DIFF
--- a/app/models/data_source_table.rb
+++ b/app/models/data_source_table.rb
@@ -8,8 +8,8 @@ class DataSourceTable
     @data_source = data_source
     @schema_name = schema_name
     @table_name = table_name
-    @full_table_name = "#{schema_name}.#{table_name}"
-    @columns = data_source.access_logging { connection.columns(full_table_name) }
+    @full_table_name = data_source.adapter == 'mysql2' ? "`#{schema_name}`.`#{table_name}`" : "#{schema_name}.#{table_name}"
+    @columns = data_source.access_logging { connection.columns("#{schema_name}.#{table_name}") }
     @defined_at = Time.now
   end
 


### PR DESCRIPTION
## Issues

`full_table_name` is not working when database name include hyphen.

## What's this PR do?

`full_table_name` have to quote when use mysql.

This is simple solution for mysql. But other adapters unresoleved, so I am not knowledgeable about them.