### PR TITLE
FIX: User email address may not be unique

### DIFF
--- a/db/users.schema
+++ b/db/users.schema
@@ -10,4 +10,3 @@ create_table "users", force: :cascade do |t|
 end
 
 add_index "users", ["provider", "uid"], name: "uniq_provider_uid", unique: true, using: :btree
-add_index "users", ["email"], name: "uniq_email", unique: true, using: :btree


### PR DESCRIPTION
User email addresses may not unique.  For example, the user who have multiple uids but with same email address is valid.

uniq_email index is not used almost, it is safe to just remove it.