### PR TITLE
Modify redshift adapter to support spectrum

### DIFF
--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -3,7 +3,7 @@ require "active_record/connection_adapters/redshift_adapter"
 module DataSourceAdapters
   class RedshiftAdapter < StandardAdapter
     def fetch_table_names
-      source_base_class.connection.query(<<~SQL, 'SCHEMA')
+      @table_names = source_base_class.connection.query(<<~SQL, 'SCHEMA')
         SELECT schemaname, tablename
         FROM (
           SELECT schemaname, tablename FROM pg_tables WHERE schemaname = ANY (current_schemas(false))
@@ -12,8 +12,43 @@ module DataSourceAdapters
         ) tables
         ORDER BY schemaname, tablename;
       SQL
+
+      @external_table_names = source_base_class.connection.query(<<~SQL, 'SCHEMA')
+        SELECT schemaname, tablename FROM svv_external_tables ORDER BY schemaname, tablename;
+      SQL
+
+      @table_names + @external_table_names
     rescue ActiveRecord::ActiveRecordError, PG::Error => e
       raise DataSource::ConnectionBad.new(e)
+    end
+
+    def fetch_columns(table)
+      adapter = connection.pool.connection
+      if spectrum?(table)
+        connection.query(<<~SQL, 'COLUMN').map { |name, sql_type| Column.new(name, sql_type, "NULL", true) }
+          SELECT columnname, external_type FROM svv_external_columns WHERE tablename = '#{table.table_name}';
+        SQL
+      else
+        connection.columns(table.full_table_name).map { |c| Column.new(c.name, c.sql_type, adapter.quote(c.default), c.null) }
+      end
+    rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
+      raise DataSource::ConnectionBad.new(e)
+    end
+
+    def fetch_rows(table, limit)
+      return [] if spectrum?(table)
+      super
+    end
+
+    def fetch_count(table)
+      return 0 if spectrum?(table)
+      super
+    end
+
+    private
+
+    def spectrum?(table)
+      @external_table_names.include?(table.full_table_name.split('.'))
     end
   end
 end


### PR DESCRIPTION
This PR is for support [Redshift Spectrum](https://aws.amazon.com/jp/blogs/news/amazon-redshift-spectrum-exabyte-scale-in-place-queries-of-s3-data/). The modification is only `redshift_adapter.rb`

- `fetch_table_names` method change to use table from `pg_tables` to `svv_tables`
  -  [the table has also external table information](https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/r_SVV_TABLES.html)
- `RedshiftAdapter` has instance variables for `BASE TABLE`, `EXTERNAL TABLE`, `VIEW`
  - to check whether a table is external table or not in `fetch_rows` / `fetch_count`
- If importing table is external, about raw dataset
  - [The price of spectrum depends on the amount of scanning data](https://aws.amazon.com/jp/redshift/pricing/#Redshift_Spectrum_Pricing),  but it is difficult to limit the volume in `fetch_rows` / `fetch_count`. 
  - `fetch_rows` : need to use partition column to reduce scan.
  - `fetch_count` : spectrum tables do not have meta data about record size. 