### PR TITLE
Support late binding view

### DIFF
--- a/app/batches/synchronize_data_sources.rb
+++ b/app/batches/synchronize_data_sources.rb
@@ -42,6 +42,7 @@ class SynchronizeDataSources
 
     columns = source_table.columns
     import_table_memo_raw_dataset!(table_memo, source_table, columns)
+    import_view_query!(table_memo, source_table)
 
     column_names = columns.map(&:name)
     column_memos.reject {|memo| column_names.include?(memo.name) }.each {|memo| memo.update!(linked: false) }
@@ -82,4 +83,17 @@ class SynchronizeDataSources
     end
   end
   private_class_method :import_table_memo_raw_dataset_rows!
+
+  def self.import_view_query!(table_memo, source_table)
+    query = source_table.fetch_view_query
+    query_plan = source_table.fetch_view_query_plan
+    if query && query_plan
+      ViewMetaDatum.find_or_initialize_by(table_memo_id: table_memo.id) do |meta_data|
+        meta_data.query = query
+        meta_data.explain = query_plan
+        meta_data.save
+      end
+    end
+  end
+  private_class_method :import_view_query!
 end

--- a/app/controllers/table_memos_controller.rb
+++ b/app/controllers/table_memos_controller.rb
@@ -15,6 +15,7 @@ class TableMemosController < ApplicationController
       @raw_dataset_columns = @raw_dataset.columns.order(:position)
       @raw_dataset_rows = @raw_dataset.rows.pluck(:row)
     end
+    @view_meta_data = @table_memo.view_meta_data
   end
 
   def edit(id)

--- a/app/models/data_source_adapters/base.rb
+++ b/app/models/data_source_adapters/base.rb
@@ -20,6 +20,14 @@ module DataSourceAdapters
       nil
     end
 
+    def fetch_view_query(view)
+      nil
+    end
+
+    def fetch_view_query_plan(query)
+      raise NotImplementedError
+    end
+
     def reset!
       raise NotImplementedError
     end

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -49,6 +49,20 @@ module DataSourceAdapters
       super
     end
 
+    def fetch_view_query(table)
+      return nil unless view?(table)
+      adapter = connection.pool.connection
+      connection.query(<<~SQL, 'VIEW QUERY').join("\n")
+        SELECT definition FROM pg_views WHERE schemaname = '#{table.schema_name}' and viewname = '#{table.table_name}';
+      SQL
+    end
+
+    def fetch_view_query_plan(query)
+      return nil if query.blank?
+      query = query.sub(/create view .*?as/, '').sub('with no schema binding', '')
+      super
+    end
+
     private
 
     def group_by_table_type(records)

--- a/app/models/data_source_adapters/standard_adapter.rb
+++ b/app/models/data_source_adapters/standard_adapter.rb
@@ -33,10 +33,6 @@ module DataSourceAdapters
       raise DataSource::ConnectionBad.new(e)
     end
 
-    def fetch_view_query(view)
-      raise NotImplementedError
-    end
-
     def fetch_view_query_plan(query)
       adapter = connection.pool.connection
       connection.query("EXPLAIN #{query}", 'EXPLAIN').join("\n")

--- a/app/models/data_source_adapters/standard_adapter.rb
+++ b/app/models/data_source_adapters/standard_adapter.rb
@@ -33,6 +33,17 @@ module DataSourceAdapters
       raise DataSource::ConnectionBad.new(e)
     end
 
+    def fetch_view_query(view)
+      raise NotImplementedError
+    end
+
+    def fetch_view_query_plan(query)
+      adapter = connection.pool.connection
+      connection.query("EXPLAIN #{query}", 'EXPLAIN').join("\n")
+    rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
+      raise DataSource::ConnectionBad.new(e)
+    end
+
     def source_base_class
       return DynamicTable.const_get(source_base_class_name) if DynamicTable.const_defined?(source_base_class_name)
 

--- a/app/models/data_source_table.rb
+++ b/app/models/data_source_table.rb
@@ -22,4 +22,12 @@ class DataSourceTable
   def fetch_count
     @data_source.access_logging { data_source_adapter.fetch_count(self) }
   end
+
+  def fetch_view_query
+    @view_query ||= @data_source.access_logging { data_source_adapter.fetch_view_query(self) }
+  end
+
+  def fetch_view_query_plan
+    @view_query_plan ||= @data_source.access_logging { data_source_adapter.fetch_view_query_plan(@view_query) }
+  end
 end

--- a/app/models/table_memo.rb
+++ b/app/models/table_memo.rb
@@ -7,6 +7,7 @@ class TableMemo < ApplicationRecord
   belongs_to :schema_memo
 
   has_one :raw_dataset, class_name: "TableMemoRawDataset", dependent: :destroy
+  has_one :view_meta_data, class_name: "ViewMetaDatum", dependent: :destroy
 
   has_many :column_memos, dependent: :destroy
   has_many :logs, -> { order(:id) }, class_name: "TableMemoLog", dependent: :destroy

--- a/app/models/view_meta_datum.rb
+++ b/app/models/view_meta_datum.rb
@@ -1,0 +1,3 @@
+class ViewMetaDatum < ApplicationRecord
+  belongs_to :table_memo
+end

--- a/app/views/table_memos/_raw_dataset.html.haml
+++ b/app/views/table_memos/_raw_dataset.html.haml
@@ -1,0 +1,29 @@
+.box.data-box
+  .box-header
+    %h3.box-title Data
+  .box-body
+    - if @raw_dataset
+      %table.table.table-hover.table-bordered.table-striped.text-sm{ role: "grid" }
+        %tr
+          - @raw_dataset_columns.each do |column|
+            %th #{column.name} (#{column.sql_type})
+        - if @table_memo.masked?
+          %tr
+            %td.text-center{ colspan: @raw_dataset_columns.size }
+              = t("masked_table")
+        - else
+          - database_name = @table_memo.database_memo.name
+          - table_name = @table_memo.name
+          - @raw_dataset_rows.each do |row|
+            %tr
+              - Array.wrap(row).each_with_index do |value, i|
+                - column = @raw_dataset_columns[i]
+                %td
+                  - if MaskedDatum.masked_column?(database_name, table_name, column.name)
+                    = t("masked_text")
+                  - else
+                    = value
+      .pull-right.block
+        #{@raw_dataset_rows.try(:size).to_i} / #{@raw_dataset.count || '?' } records
+    - else
+      = t("no_preview_dataset")

--- a/app/views/table_memos/_view_meta_data.html.haml
+++ b/app/views/table_memos/_view_meta_data.html.haml
@@ -1,0 +1,14 @@
+.box.data-box
+  .box-header
+    %h3.box-title View Query
+  .box-body
+    %pre
+      %code= @view_meta_data.query
+
+.box.data-box
+  .box-header
+    %h3.box-title View Query Plan
+  .box-body
+    %pre
+      %code= @view_meta_data.explain
+

--- a/app/views/table_memos/show.html.haml
+++ b/app/views/table_memos/show.html.haml
@@ -60,32 +60,7 @@
         %th Nullable
       = render partial: "column_memo", collection: @table_memo.column_memos.sort_by(&:display_order)
 
-.box.data-box
-  .box-header
-    %h3.box-title Data
-  .box-body
-    - if @raw_dataset
-      %table.table.table-hover.table-bordered.table-striped.text-sm{ role: "grid" }
-        %tr
-          - @raw_dataset_columns.each do |column|
-            %th #{column.name} (#{column.sql_type})
-        - if @table_memo.masked?
-          %tr
-            %td.text-center{ colspan: @raw_dataset_columns.size }
-              = t("masked_table")
-        - else
-          - database_name = @table_memo.database_memo.name
-          - table_name = @table_memo.name
-          - @raw_dataset_rows.each do |row|
-            %tr
-              - Array.wrap(row).each_with_index do |value, i|
-                - column = @raw_dataset_columns[i]
-                %td
-                  - if MaskedDatum.masked_column?(database_name, table_name, column.name)
-                    = t("masked_text")
-                  - else
-                    = value
-      .pull-right.block
-        #{@raw_dataset_rows.try(:size).to_i} / #{@raw_dataset.count || '?' } records
-    - else
-      = t("no_preview_dataset")
+- if @view_meta_data
+  = render partial: "view_meta_data"
+- else
+  = render partial: "raw_dataset"

--- a/db/view_meta_data.schema
+++ b/db/view_meta_data.schema
@@ -1,0 +1,6 @@
+create_table "view_meta_data", force: :cascade do |t|
+  t.integer "table_memo_id",              null: false
+  t.text    "query",                      null: false
+  t.text    "explain",                    null: false
+  t.datetime "created_at",                null: false
+end

--- a/spec/models/data_source_adapters/mysql2_adapter_spec.rb
+++ b/spec/models/data_source_adapters/mysql2_adapter_spec.rb
@@ -26,6 +26,7 @@ describe DataSourceAdapters::Mysql2Adapter, type: :model do
       CREATE TABLE IF NOT EXISTS #{table.table_name} (id INT PRIMARY KEY);
       TRUNCATE TABLE #{table.table_name};
       INSERT INTO #{table.table_name} VALUES (1);
+      ANALYZE TABLE #{table.table_name};
     SQL
   end
 


### PR DESCRIPTION
This PR is for support [late-binding view](https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/r_CREATE_VIEW.html#r_CREATE_VIEW_usage_notes). The PR has 3 modification about late binding view.

1. add [`pg_get_late_binding_view_cols`](https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/PG_GET_LATE_BINDING_VIEW_COLS.html) to `fetch_table_names method` in redshift_adapter
    - instance variable for `LATE BINDING`
    - change `fetch_column` source table to [`svv_columns`](https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/r_SVV_COLUMNS.html)
2. fetch meta data of view, a query of view and a planning of the query
3. show the meta data
    - `ViewMetaDatum` model
    - split to partial views, `_raw_dataset` and `_view_meta_data` in `table_memo#show`

If the table of a memo page is view regardless whether late binding or not, show the meta data like the following.

![sample image](https://user-images.githubusercontent.com/2664198/55368949-5dfa0100-552f-11e9-9fe9-961dce7e2ac7.png)