### PR TITLE
Upgrade dmemo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.3.7-node
+      - image: circleci/ruby:2.6.2-node
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ### Changed
 - Use INFORMATION_SCHEMA system table in mysql2 adapter to count rows
 
+## 0.8.0
+- Support Spectrum schema of AWS Redshift [#117](https://github.com/hogelog/dmemo/pull/117)
+- Support late binding view of AWS Redshfit [#118](https://github.com/hogelog/dmemo/pull/118)
+- Upgrade to Ruby v2.6.2 and Debian Stretch
+
 ## 0.7.0
 - ignored_tables settings also ignore schema
   - This is possible breaking change. Your schemas may be ignored depending on ignored_tables settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # CHANGELOG
 
 ## Unreleased
-### Changed
-- Use INFORMATION_SCHEMA system table in mysql2 adapter to count rows
 
 ## 0.8.0
+- Use INFORMATION_SCHEMA system table in mysql2 adapter to count rows [#114](https://github.com/hogelog/dmemo/pull/114)
 - Support Spectrum schema of AWS Redshift [#117](https://github.com/hogelog/dmemo/pull/117)
 - Support late binding view of AWS Redshfit [#118](https://github.com/hogelog/dmemo/pull/118)
 - Upgrade to Ruby v2.6.2 and Debian Stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ruby:2.3.1-slim
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev libmysqlclient-dev nodejs nodejs-legacy npm git
+FROM ruby:2.6.2-slim-stretch
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev default-libmysqlclient-dev nodejs-legacy curl git
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
+RUN apt-get -y install nodejs
 RUN mkdir /app
 
 ADD Gemfile /tmp/Gemfile

--- a/lib/autoload/dmemo/version.rb
+++ b/lib/autoload/dmemo/version.rb
@@ -1,3 +1,3 @@
 module Dmemo
-  VERSION = "0.4.1"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
`ruby:2.3.1-slim` uses Debian 8 "Jessie", but this distribution is [comming to an end of support.](https://wiki.debian.org/LTS/)
Docker build fail because packages cannot update. ( [jessie-updates does not exist](http://cdn-fastly.deb.debian.org/debian/dists/) )

1. bump up Ruby and Debian version
   - replace libmysqlclient-dev to default-libmysqlclient-dev https://packages.debian.org/ja/stretch/default-libmysqlclient-dev
   - change how to install nodejs and npm  https://github.com/nodesource/distributions
   - bump up ci ruby version
2. bump up dmemo version

please review @hogelog 