### PR TITLE
Case insensitive searching

### DIFF
--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -9,7 +9,7 @@ class SearchResult
 
   def search!
     return unless keyword.present?
-    self.results += TableMemo.where("table_memos.name LIKE ?", "%#{keyword}%").eager_load(schema_memo: :database_memo).to_a
-    self.results += ColumnMemo.where("column_memos.name LIKE ?", "%#{keyword}%").eager_load(table_memo: {schema_memo: :database_memo}).to_a
+    self.results += TableMemo.where("table_memos.name ILIKE ?", "%#{keyword}%").eager_load(schema_memo: :database_memo).to_a
+    self.results += ColumnMemo.where("column_memos.name ILIKE ?", "%#{keyword}%").eager_load(table_memo: {schema_memo: :database_memo}).to_a
   end
 end


### PR DESCRIPTION
- Using `ILIKE` instead `LIKE` matches case insensitive.
  https://www.postgresql.org/docs/8.3/functions-matching.html
- #122