### PR TITLE
Fix import redshift late binding view

### DIFF
--- a/app/batches/synchronize_data_sources.rb
+++ b/app/batches/synchronize_data_sources.rb
@@ -87,10 +87,10 @@ class SynchronizeDataSources
   def self.import_view_query!(table_memo, source_table)
     query = source_table.fetch_view_query
     query_plan = source_table.fetch_view_query_plan
-    if query && query_plan
+    if query
       ViewMetaDatum.find_or_initialize_by(table_memo_id: table_memo.id) do |meta_data|
         meta_data.query = query
-        meta_data.explain = query_plan
+        meta_data.explain = query_plan || 'explain error'
         meta_data.save
       end
     end

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -60,7 +60,8 @@ module DataSourceAdapters
 
     def fetch_view_query_plan(query)
       return nil if query.blank?
-      query = query.sub(/create view .*?as/, '').sub('with no schema binding', '')
+      # to explain, extract of select statement from view query without 'with no schema binding'
+      query = query.match(/select(.|\n)+/)[0].sub('with no schema binding', '')
       super
     end
 

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -61,7 +61,7 @@ module DataSourceAdapters
     def fetch_view_query_plan(query)
       return nil if query.blank?
       # to explain, extract of select statement from view query without 'with no schema binding'
-      query = query.match(/select(.|\n)+/)[0].sub('with no schema binding', '')
+      query = query.match(/select(.|\n)+/i)[0].sub(/\)? ?with no schema binding/, '')
       super
     end
 


### PR DESCRIPTION
Fix bug of late binding view data.
When execute `explain #{query}`, the query is extracted from a view definition by regex substring.
The regex was wrong, and some view cannot show view definition and query plan on a table memo page at Dmemo site.

This PR fixes regex and considering to occur error by query plan.