### PR TITLE
Add formagtting code for view query in view memo page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'addressable'
 
 gem 'bootsnap'
 
+gem 'anbt-sql-formatter', require: 'anbt-sql-formatter/formatter'
+
 group :development, :test do
   gem 'byebug'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    anbt-sql-formatter (0.1.0)
     arel (9.0.0)
     ast (2.4.0)
     bootsnap (1.3.2)
@@ -370,6 +371,7 @@ DEPENDENCIES
   active_decorator
   activerecord5-redshift-adapter
   addressable
+  anbt-sql-formatter
   bootsnap
   brakeman
   byebug

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,12 @@ module ApplicationHelper
   def markdown_html(markdown)
     Markdown.new(markdown).html
   end
+
+  def sql_query_format(query)
+    rule = AnbtSql::Rule.new
+    rule.indent_string = '  '
+    rule.space_after_comma = true
+    formatter = AnbtSql::Formatter.new(rule)
+    formatter.format(query)
+  end
 end

--- a/app/views/table_memos/_view_meta_data.html.haml
+++ b/app/views/table_memos/_view_meta_data.html.haml
@@ -3,7 +3,7 @@
     %h3.box-title View Query
   .box-body
     %pre
-      %code= @view_meta_data.query
+      %code= sql_query_format(@view_meta_data.query)
 
 .box.data-box
   .box-header


### PR DESCRIPTION
I added view information to table memo page ( [PR](https://github.com/hogelog/dmemo/pull/118) )

A query in the `View Query` box is not formatted, so the view definition is very unreadable.
This PR is to apply to format query of a view memo page.


TBD: Is it realy to use this library?