### PR TITLE
Handle import view query

### DIFF
--- a/app/batches/synchronize_data_sources.rb
+++ b/app/batches/synchronize_data_sources.rb
@@ -88,8 +88,9 @@ class SynchronizeDataSources
     return unless source_table.data_source.adapter.is_a?(DataSourceAdapters::RedshiftAdapter)
 
     query = source_table.fetch_view_query
-    query_plan = source_table.fetch_view_query_plan
     if query
+      query_plan = source_table.fetch_view_query_plan
+
       ViewMetaDatum.find_or_initialize_by(table_memo_id: table_memo.id) do |meta_data|
         meta_data.query = query
         meta_data.explain = query_plan || 'explain error'

--- a/app/batches/synchronize_data_sources.rb
+++ b/app/batches/synchronize_data_sources.rb
@@ -85,6 +85,8 @@ class SynchronizeDataSources
   private_class_method :import_table_memo_raw_dataset_rows!
 
   def self.import_view_query!(table_memo, source_table)
+    return unless source_table.data_source.adapter.is_a?(DataSourceAdapters::RedshiftAdapter)
+
     query = source_table.fetch_view_query
     query_plan = source_table.fetch_view_query_plan
     if query

--- a/spec/batches/synchronize_data_sources_spec.rb
+++ b/spec/batches/synchronize_data_sources_spec.rb
@@ -21,6 +21,9 @@ describe SynchronizeDataSources do
       table_memos = schema_memo.table_memos
       expect(table_memos.find_by!(name: "data_sources")).to be_present
 
+      column_memos = table_memos.find_by!(name: "data_sources").column_memos
+      expect(column_memos).to be_present
+
       dataset = table_memos.find_by!(name: "data_sources").raw_dataset
       expect(dataset.count).to eq(1)
       expect(dataset.columns.map(&:name)).to match_array(%w(id name description adapter host port dbname user password encoding pool created_at updated_at))


### PR DESCRIPTION
After #118,  in case of without using 
 RedshiftAdapter, `SynchronizeDataSources` batch fails to sync column_memos and existed table_memos changing.
\# In our case, we use mysql2 adapter.

This PR makes import_view_query method process only in case of using RedshiftAdapter.

Please review it @hogelog
