### PR TITLE
Fix login error caused by omniauth v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'github-markdown'
 gem 'active_decorator'
 
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 
 gem 'revision_plate', require: 'revision_plate/rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,9 @@ GEM
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     os (1.1.1)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -411,6 +414,7 @@ DEPENDENCIES
   mysql2
   non-stupid-digest-assets
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 0.15)
   presto-client
   pry-byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   def require_login
     return if current_user
-    redirect_to google_oauth2_path(state: request.fullpath)
+    redirect_to sign_in_path(return_to: url_for(params.to_unsafe_h.merge(only_path: true)))
   end
 
   def require_admin_login

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,0 +1,5 @@
+.content
+  %p.lead Required sign in to access Dmemo.
+  = button_to google_oauth2_path(return_to: params[:return_to]), class: 'btn btn-default', method: :post do
+    %i.fa.fa-google
+    %span Sign in with Google

--- a/app/views/shared/_main_sidebar.html.haml
+++ b/app/views/shared/_main_sidebar.html.haml
@@ -1,10 +1,11 @@
 %aside.main-sidebar
   %section.sidebar
-    .user-panel
-      .pull-left.image
-        = image_tag current_user.image_url, class: "img-rounded"
-      .pull-left.info
-        %p= current_user.name
+    - if current_user
+      .user-panel
+        .pull-left.image
+          = image_tag current_user.image_url, class: "img-rounded"
+        .pull-left.info
+          %p= current_user.name
 
     = form_for @search_result, method: :get, html: { class: "sidebar-form" } do |f|
       .input-group

--- a/app/views/shared/_navbar.html.haml
+++ b/app/views/shared/_navbar.html.haml
@@ -1,15 +1,16 @@
 %nav.navbar.navbar-static-top{ role: "navigation" }
   .navbar-custom-menu
-    %ul.nav.navbar-nav
-      %li
-        = link_to setting_path do
-          %i.fa.fa-gear
-          Setting
-      %li
-        = link_to edit_user_path(current_user) do
-          %i.fa.fa-user
-          = current_user.name
-      %li
-        = link_to logout_path, method: :delete do
-          %i.fa.fa-sign-out
-          Sign-out
+    - if current_user
+      %ul.nav.navbar-nav
+        %li
+          = link_to setting_path do
+            %i.fa.fa-gear
+            Setting
+        %li
+          = link_to edit_user_path(current_user) do
+            %i.fa.fa-user
+            = current_user.name
+        %li
+          = link_to logout_path, method: :delete do
+            %i.fa.fa-sign-out
+            Sign-out

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,9 @@ Rails.application.routes.draw do
   end
   get "/keywords/*id", to: "keywords#show", format: false
 
-  get 'auth/google_oauth2', as: :google_oauth2, to: lambda { |_env| [500, {}, 'Never called'] }
-  get "auth/google_oauth2/callback", to: "sessions#create"
+  get "sign_in", to: "sessions#new"
+
+  post "auth/google_oauth2", as: :google_oauth2, to: lambda { |_env| [500, {}, 'Never called'] }
+  get "auth/google_oauth2/callback", to: "sessions#callback"
   delete "logout", to: "sessions#destroy"
 end


### PR DESCRIPTION
PR  https://github.com/hogelog/dmemo/pull/252 which I merged yesterday contained a bug related to omniauth v2. 
This PR resolves the bug and makes it correctly support with omniauth v2.

1. Add omniauth-rails_csrf_protection gem
2. Add a view for the sign-in button (`app/views/sessions/new.html.haml`)
3. Change POST instead of GET for `auth/google_oauth2`
4. Add redirect to the original URL after sign-in

![スクリーンショット 2021-06-15 22 46 27](https://user-images.githubusercontent.com/2664198/122068229-30a77e00-ce2f-11eb-9ca7-976b222405be.png)
