### PR TITLE
Fix sql to get raw data from Redshift Spectrum table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # CHANGELOG
 
 ## Unreleased
+
+## 0.8.1 (Not released)
 - Upgrade gems not versioned in Gemfile [#252](https://github.com/hogelog/dmemo/pull/252)
 - Support Omniauth v2 [#256](https://github.com/hogelog/dmemo/pull/256)
 - Upgrade to Ruby v3.0.0 and Rails v6.1.3 [#253](https://github.com/hogelog/dmemo/pull/253)
+- Fix SQL to get raw data from Redshift Spectrum [#258](https://github.com/hogelog/dmemo/pull/258)
 
 ## 0.8.0
 - Use INFORMATION_SCHEMA system table in mysql2 adapter to count rows [#114](https://github.com/hogelog/dmemo/pull/114)

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -49,9 +49,8 @@ module DataSourceAdapters
     def fetch_spectrum_rows(table, limit)
       adapter = connection.pool.connection
       column_names = table.columns.map { |column| adapter.quote_column_name(column.name) }.join(", ")
-      rows = connection.select_rows(<<~SQL, "#{table.full_table_name.classify} Load")
-        SELECT #{column_names} FROM #{adapter.quote_table_name(table.full_table_name)} LIMIT #{limit};
-      SQL
+      sql = "SELECT #{column_names} FROM #{adapter.quote_table_name(table.full_table_name)} LIMIT #{limit};"
+      rows = connection.select_rows(sql, "#{table.full_table_name.classify} Load")
     rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
       raise DataSource::ConnectionBad.new(e)
     end

--- a/app/models/data_source_adapters/redshift_adapter.rb
+++ b/app/models/data_source_adapters/redshift_adapter.rb
@@ -48,8 +48,9 @@ module DataSourceAdapters
 
     def fetch_spectrum_rows(table, limit)
       adapter = connection.pool.connection
+      column_names = table.columns.map { |column| adapter.quote_column_name(column.name) }.join(", ")
       rows = connection.select_rows(<<~SQL, "#{table.full_table_name.classify} Load")
-        SELECT * FROM #{adapter.quote_table_name(table.full_table_name)} LIMIT #{limit};
+        SELECT #{column_names} FROM #{adapter.quote_table_name(table.full_table_name)} LIMIT #{limit};
       SQL
     rescue ActiveRecord::ActiveRecordError, Mysql2::Error, PG::Error => e
       raise DataSource::ConnectionBad.new(e)


### PR DESCRIPTION
I've written a code before for Spectrum support.
https://github.com/hogelog/dmemo/pull/125/files

```sql
SELECT * FROM #{adapter.quote_table_name(table.full_table_name)} LIMIT #{limit}
```

This code was considered to be SQL injection by Hakiri .
The asterisk should have been `#{column_names}`. 

```ruby
column_names = raw_columns(table).map { |column| adapter.quote_column_name(column.name) }.join(", ")
```

However, if I made column_names like this, as I do with the inherited `StandardAdapter`, I got a PG error at `raw_columns`.

```irb
[3] pry(#<DataSourceAdapters::RedshiftAdapter>)> raw_columns(table)
ActiveRecord::StatementInvalid: PG::FeatureNotSupported: ERROR: Operation not supported on external tables

from /Users/ichinari-sato/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/activerecord6-redshift-adapter-1.2.1/lib/active_record/ connection_adapters/redshift/database_statements.rb:153:in `exec'
Caused by PG::FeatureNotSupported: ERROR: Operation not supported on external tables
````

I gave up on PR#125 when I saw this error, but it was just a matter of getting all the columns from the table information.
In this PR, I stop using asterisks and back to normal the Hakiri CI.