### PR TITLE
Modify search result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Modify listed item UI [#263](https://github.com/hogelog/dmemo/pull/263)
 - Improve visibility in browser tab [#262](https://github.com/hogelog/dmemo/pull/262)
+- Modify search result page [#268](https://github.com/hogelog/dmemo/pull/268)
+
 ## 0.8.1
 - Upgrade gems not versioned in Gemfile [#252](https://github.com/hogelog/dmemo/pull/252)
 - Support Omniauth v2 [#256](https://github.com/hogelog/dmemo/pull/256)

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'sprockets', '~>3.7' # fix sprockets version under v3.x
 gem 'jquery-rails'
 
 gem 'haml-rails'
+gem 'kaminari'
 
 gem 'jbuilder'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,18 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.5.1)
     jwt (2.2.3)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     loofah (2.10.0)
@@ -419,6 +431,7 @@ DEPENDENCIES
   html-pipeline
   jbuilder
   jquery-rails
+  kaminari
   launchy
   mysql2
   non-stupid-digest-assets

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -3,6 +3,6 @@ class SearchResultsController < ApplicationController
 
   def show(search_result)
     @search_result = SearchResult.new(search_result)
-    @search_result.search!
+    @search_result.search!(table_page: params[:table_page], column_page: params[:column_page], per_page: 30)
   end
 end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -1,16 +1,17 @@
 class SearchResult
   include ActiveModel::Model
-  attr_accessor :keyword, :results
+  attr_accessor :keyword, :tables, :columns
 
-  def initialize(*args)
-    super
-    self.results = []
-  end
-
-  def search!
+  def search!(table_page:, column_page:, per_page:)
     return unless keyword.present?
     pattern = "%#{keyword}%"
-    self.results += TableMemo.where("table_memos.name LIKE ? OR table_memos.description LIKE ?", pattern, pattern).eager_load(schema_memo: :database_memo).to_a
-    self.results += ColumnMemo.where("column_memos.name LIKE ? OR column_memos.description LIKE ?", pattern, pattern).eager_load(table_memo: {schema_memo: :database_memo}).to_a
+    self.tables  = TableMemo.where("table_memos.name LIKE ? OR table_memos.description LIKE ?", pattern, pattern)
+                            .eager_load(schema_memo: :database_memo)
+                            .order(description: :desc, updated_at: :desc)
+                            .page(table_page).per(per_page)
+    self.columns = ColumnMemo.where("column_memos.name LIKE ? OR column_memos.description LIKE ?", pattern, pattern)
+                            .eager_load(table_memo: {schema_memo: :database_memo})
+                            .order(description: :desc, updated_at: :desc)
+                            .page(column_page).per(per_page)
   end
 end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -9,7 +9,8 @@ class SearchResult
 
   def search!
     return unless keyword.present?
-    self.results += TableMemo.where("table_memos.name LIKE ?", "%#{keyword}%").eager_load(schema_memo: :database_memo).to_a
-    self.results += ColumnMemo.where("column_memos.name LIKE ?", "%#{keyword}%").eager_load(table_memo: {schema_memo: :database_memo}).to_a
+    pattern = "%#{keyword}%"
+    self.results += TableMemo.where("table_memos.name LIKE ? OR table_memos.description LIKE ?", pattern, pattern).eager_load(schema_memo: :database_memo).to_a
+    self.results += ColumnMemo.where("column_memos.name LIKE ? OR column_memos.description LIKE ?", pattern, pattern).eager_load(table_memo: {schema_memo: :database_memo}).to_a
   end
 end

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.disabled
+  = content_tag :a, raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote }

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel
+- else
+  %li
+    = link_to page, url, remote: remote, rel: page.rel

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,11 @@
+= paginator.render do
+  %ul.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.left_outer? || page.right_outer? || page.inside_window?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote

--- a/app/views/search_results/show.html.haml
+++ b/app/views/search_results/show.html.haml
@@ -1,22 +1,29 @@
 - content_for :title, "\"#{@search_result.keyword}\" « Search"
 - content_for :header do
   %h1.page-header "#{@search_result.keyword}" search result
+  %p #{@search_result.tables.total_count} Table hits / #{@search_result.columns.total_count} Column hits
 
-- unless @search_result.results.present?
+- unless @search_result.tables.present? || @search_result.columns.present?
   .box
     .box-body
       No results found.
 - else
-  - @search_result.results.each do |result|
+  - @search_result.tables.each do |result|
     .box
       .box-header.with-border
         %h3.box-title
-          - case result
-          - when TableMemo
-            %small.label.bg-green Table
-            = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
-          - when ColumnMemo
-            %small.label.bg-aqua-active Column
-            = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
+          %small.label.bg-green Table
+          = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
       .box-body
-        = highlight(markdown_html(result.description), @search_result.keyword).html_safe
+        = highlight(markdown_html(result.description).html_safe, @search_result.keyword)
+  = paginate @search_result.tables, param_name: 'table_page'
+
+  - @search_result.columns.each do |result|
+    .box
+      .box-header.with-border
+        %h3.box-title
+          %small.label.bg-aqua-active Column
+          = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
+      .box-body
+        = highlight(markdown_html(result.description).html_safe, @search_result.keyword)
+  = paginate @search_result.columns, param_name: 'column_page'

--- a/app/views/search_results/show.html.haml
+++ b/app/views/search_results/show.html.haml
@@ -14,9 +14,9 @@
           - case result
           - when TableMemo
             %small.label.bg-green Table
-            = link_to result.full_name, url_for(result)
+            = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
           - when ColumnMemo
             %small.label.bg-green Column
-            = link_to result.full_name, url_for(result)
+            = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
       .box-body
-        = markdown_html(result.description).html_safe
+        = highlight(markdown_html(result.description), @search_result.keyword).html_safe

--- a/app/views/search_results/show.html.haml
+++ b/app/views/search_results/show.html.haml
@@ -16,7 +16,7 @@
             %small.label.bg-green Table
             = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
           - when ColumnMemo
-            %small.label.bg-green Column
+            %small.label.bg-aqua-active Column
             = link_to highlight(result.full_name, @search_result.keyword), url_for(result)
       .box-body
         = highlight(markdown_html(result.description), @search_result.keyword).html_safe


### PR DESCRIPTION
This PR is a change to make the search results easier to read.
It used to time out when searching for words with a large number of hits, such as `id`. I add pagination to avoid the timeout.
The PR changes are as follows

1. highlight search terms
2. changed the color of column labels to distinguish them from table labels.
3. make description also searchable
4. added pagination (and add `.order(description: :desc, updated_at: :desc)`)

![スクリーンショット 2021-07-05 12 07 58](https://user-images.githubusercontent.com/2664198/124413572-e6f5e780-dd8b-11eb-8770-3fea8b6f2cef.png)

TODO
The search result page searches the table and column at the same time and displays them at the same time. As it is, it looks non-intuitive UI, performs poorly, and is cumbersome to code.
I would like to take one of the following actions.  I couldn't decide which one is better, so in this PR I'm still searching both and paginating both.

1. exclude columns from the search
2. separate table search and column search
