### PR TITLE
[fix] value too long for type character varying(200)

### DIFF
--- a/db/users.schema
+++ b/db/users.schema
@@ -3,7 +3,7 @@ create_table "users", force: :cascade do |t|
   t.string   "uid",        limit: 40,                  null: false
   t.string   "name",       limit: 40,                  null: false
   t.string   "email",      limit: 40,                  null: false
-  t.string   "image_url",  limit: 200,                 null: false
+  t.text     "image_url",                              null: false
   t.boolean  "admin",                  default: false, null: false
   t.datetime "created_at",                             null: false
   t.datetime "updated_at",                             null: false


### PR DESCRIPTION
Profile image URL can be longer than 200 bytes (chars?).

We can have a profile image URL like `https://lh3.googleusercontent.com/a-/AOh14GgKgdWavdr2-phkF8BNzKNmIDv88Pb-ubjMaO7Td4rc8Er-0byyjV35BVO8Ua72T-8JZ-Bgjv1XdkGq5_26BrVeyAoJu3KRfQZRF6nx9_bZr3qanMT8eZWncNYhxZBZnSVgfygQKQ3wRAuLTX8nkcIRAf-kysjBMpjPV3nOof9k_PzCBdF0DJBKqGRdFzQTGcKUSNxj0O6HalijAssSjWdkdRIGGaB2q1rxZqqNW6Mz17TshFVc3oxu-b52ahQXlM9PiDGBZv9bFlLXSPLx8Mm2oJC4ZMlRu0JGUyG3EI-7XCzRqoSpB1_iBKhkqkdRmMH398ZWMoF7Z9Mn0-ynHTFTmiGcPCyF4qaz3yb8WHgQ0QECg9eVof933ezR45z3_Qnvc046uVsiNmBkUsCEftAJBeFx92gpkrsHFyFheRdxfYPitaW8NePRgA9IhrS0cO08g8NHVW27GwJwhRHGZVrIA-BQKfkLO1_iRVkfdSSDlAnlNAff_N7gVXIxt4484Dp6SLkMjF4dMJLIFK_GIOHruv4odpfi8IhX1xvApnxfGQ-2tH-uxVMXq6FaFZ_ED_9SqcEQ_AhIBvWB6i0RXdey6vDwFYpcHKAKHlHRBk_OwEzKXMfS05YJEfLbZoA-lWxo2Oku-rc9WtPnErJbvnU24uhExtpmpqWM6hnPzU1uDTr1iR2_mhUsQTPDHxbQMkUt-bsol32snfDiRVT0vw6pOr3WZQHvCMrguvgH5FzTPp03GV-vJKWgS5HvlKvXBBbPqg=s96-c` and this cause `ERROR:  value too long for type character varying(200)` when creating a user.