### PR TITLE
Reduce application log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 
 gem 'revision_plate', require: 'revision_plate/rails'
+gem 'silencer'
 
 gem 'puma'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,7 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    silencer (1.0.1)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -456,6 +457,7 @@ DEPENDENCIES
   rubocop
   ruby-prof
   sass-rails (~> 6.0)
+  silencer
   simplecov
   sprockets (~> 3.7)
   uglifier (>= 1.3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,9 +49,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # production is not a development environment. Don't need :debug log for development.
+  # We just need to find out where the problem is.
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -1,0 +1,8 @@
+Rails.application.configure do
+  config.middleware.swap(
+    Rails::Rack::Logger,
+    Silencer::Logger,
+    config.log_tags,
+    silence: ["/site/sha"]
+  )
+end


### PR DESCRIPTION
In our environment, we have not set RAILS_LOG_TO_STDOUT and have not seen the application log of Dmemo.

When we set it the other day to investigate a bug, we found that there was a lot of unnecessary log output. Since it is difficult to see the logs as they are, we will suppress the amount of log output.

The debug log is only for local development use.