### PR TITLE
Show column name when editing column memo

### DIFF
--- a/app/views/column_memos/edit.html.haml
+++ b/app/views/column_memos/edit.html.haml
@@ -1,2 +1,5 @@
 .box.box-info.with-border
+  .box-header
+    %h4
+      = @column_memo.name
   = render "shared/description_editor", memo: @column_memo


### PR DESCRIPTION
When editing a column memo, it is easy to forget which column you are editing. Adding the column name to the description editor lightbox helps you remember where you are.

Before | After
---|---
<img width="568" alt="Screen Shot 2021-10-28 at 17 36 46" src="https://user-images.githubusercontent.com/3714/139219337-62ea5c8e-0471-4eb0-a235-1ad4fa3557fd.png"> | <img width="600" alt="Screen Shot 2021-10-28 at 17 36 21" src="https://user-images.githubusercontent.com/3714/139219316-1d8daf99-51f8-4735-8a06-0b3fc6c48e10.png">

I added this to the column memo editor, and not the shared description editor, because there is sufficient context when editing the table memo, so this piece of UI is not necessary in the table memo description editing context.



